### PR TITLE
fix: defer ios bluetooth setup

### DIFF
--- a/ios/Classes/TtlockFlutterPlugin.m
+++ b/ios/Classes/TtlockFlutterPlugin.m
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, ErrorDevice) {
 
 @end
 
+
 @implementation TtlockFlutterPlugin
 
 
@@ -43,19 +44,55 @@ typedef NS_ENUM(NSInteger, ErrorDevice) {
     static TtlockFlutterPlugin *instance = nil;
     if (!instance) {
         instance = [[self alloc] init];
+    }
+    return instance;
+}
+
+// Defer the TTLock Bluetooth setup until the app invokes a command that needs
+// Bluetooth. Creating the Bluetooth manager during plugin registration makes
+// iOS show the permission dialog at app launch, before the host app can present
+// the request in context.
++ (void)setupBluetoothIfNeeded {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         [TTLock setupBluetooth:^(TTBluetoothState state) {
             if (state != TTBluetoothStatePoweredOn) {
                 NSLog(@"####### Bluetooth is off or un unauthorized ########");
             }
         }];
-    }
-    return instance;
+    });
+}
+
++ (BOOL)commandNeedsBluetoothSetup:(NSString *)command {
+    NSArray *commandsWithoutBluetoothSetup = @[
+        command_setup_plugin,
+        command_get_bluetooth_state,
+        command_get_blutetooth_scan_state,
+        command_function_support,
+        command_gateway_get_network_mac,
+        command_standalone_door_sensor_support_function,
+        command_electric_meter_support_function,
+        command_water_meter_support_function,
+        command_stop_scan_lock,
+        command_stop_scan_gateway,
+        command_remote_key_stop_scan,
+        command_door_sensor_stop_scan,
+        command_standalone_door_sensor_stop_scan,
+        command_remote_keypad_stop_scan,
+        command_electric_meter_stop_scan,
+        command_water_meter_stop_scan
+    ];
+    return ![commandsWithoutBluetoothSetup containsObject:command];
 }
 
 #pragma mark  - FlutterPlugin
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result{
     __weak TtlockFlutterPlugin *weakSelf = self;
     NSString *command = call.method;
+    BOOL needsBluetoothSetup = [TtlockFlutterPlugin commandNeedsBluetoothSetup:command];
+    if (needsBluetoothSetup) {
+        [TtlockFlutterPlugin setupBluetoothIfNeeded];
+    }
     NSObject *arguments = call.arguments;
     TtlockModel *lockModel = nil;
     if ([arguments isKindOfClass:NSDictionary.class]) {
@@ -65,7 +102,7 @@ typedef NS_ENUM(NSInteger, ErrorDevice) {
         lockModel.lockData = (NSString *)arguments;
     }
     
-    if (TTLock.bluetoothState != TTBluetoothStatePoweredOn) {
+    if (needsBluetoothSetup && TTLock.bluetoothState != TTBluetoothStatePoweredOn) {
         NSLog(@"####### Bluetooth is off or un unauthorized ########");
     }
     
@@ -2010,4 +2047,3 @@ typedef NS_ENUM(NSInteger, ErrorDevice) {
 }
 
 @end
-


### PR DESCRIPTION
## Summary

- Move iOS TTLock Bluetooth setup out of plugin registration.
- Initialize Bluetooth lazily before commands that need Bluetooth access.
- Keep passive/status commands such as getBluetoothState, getBluetoothScanState, setupPlugin, stop-scan commands, and support-feature helpers from triggering Bluetooth setup.

## Motivation

Closes #30.

Registering the Flutter plugin currently creates the TTLock Bluetooth manager immediately. On iOS, that can show the Bluetooth permission prompt at app launch even if the app has not presented any Bluetooth-related UI yet. Deferring setup lets host apps request Bluetooth access in context, for example when the user starts scanning for locks or performs another Bluetooth operation.

This follows platform permission guidance to request access when the feature clearly needs it:

- Apple Human Interface Guidelines: https://developer.apple.com/design/human-interface-guidelines/privacy
- Android Bluetooth permissions guidance: https://developer.android.com/develop/connectivity/bluetooth/bt-permissions

The Android link is included for the general runtime-permission principle; this change is intentionally scoped to iOS.

## Validation

- git diff --check
- flutter analyze --no-pub

Note: flutter analyze still reports existing Dart warnings in the example and meter files that are unrelated to this iOS change.

## Manual testing

This is opened as a draft because the iOS system permission prompt behavior should be verified on a physical device:

1. Launch an app that depends on this plugin without invoking a TTLock Bluetooth command.
2. Confirm iOS does not show the Bluetooth permission prompt at launch.
3. Start a lock scan or another Bluetooth operation.
4. Confirm the prompt appears only at that point.